### PR TITLE
expose browserSync instance

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ function Plugin(options) {
   self.options = options;
   self.webpackIsWatching = false;
   self.browserSyncIsRunning = false;
+  self.browserSync = browserSync;
 }
 
 Plugin.prototype.apply = function (compiler) {


### PR DESCRIPTION
This gives access to the inner browserSync instance used by the plugin. I needed it to call ````reload````.

Example:
````
var browserSyncPlugin = new BrowserSyncPlugin();
browserSyncPlugin.browserSync.reload({stream: true});
````