### PR TITLE
Adds a "use" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ module.exports = {
             // might be useful if you combine this plugin
             // with webpack-dev-server to reach
             // Hot Loader/Hot Module Replacement tricks
-            reload: true
+            reload: true,
+
+            // Configure the browserSync instance by calling "use" with the supplied value(s).
+            // eg. use: require('browser-sync-spa')()
+            use: function || [function]
           }
         )
     ]

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function Plugin(browserSyncOptions, options) {
   var defaultOptions = {
     reload: true,
     name: 'bs-webpack-plugin',
+    use: [],
     callback: undefined
   };
 
@@ -14,6 +15,14 @@ function Plugin(browserSyncOptions, options) {
   self.options = _.extend({}, defaultOptions, options);
 
   self.browserSync = browserSync.create(self.options.name);
+  if (!_.isArray(self.options.use)) {
+    self.options.use = [self.options.use];
+  }
+
+  self.options.use.forEach(function(o) {
+    self.browserSync.use(o);
+  });
+
   self.webpackIsWatching = false;
   self.browserSyncIsRunning = false;
 }


### PR DESCRIPTION
Hello,

This PR adds a use option, allowing the browserSync instance to be further configured.

My use case for adding this feature was a need to use the [browser-sync-spa module](https://github.com/shakyShane/browser-sync-spa/blob/master/client.js) to enable `history.pushState` support within a Backbone app.

