### PR TITLE
Clarify function name

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var _ = require('lodash');
 var browserSync = require('browser-sync');
 
-function Plugin(browserSyncOptions, options) {
+function BrowserSyncPlugin(browserSyncOptions, options) {
   var self = this;
 
   var defaultOptions = {


### PR DESCRIPTION
If you were for example to `console.log` your array of webpack plugins, naming it like this makes it very clear which plugin it is :grin: