### PR TITLE
Add browserSync notification upon compilation step

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ BrowserSyncPlugin.prototype.apply = function (compiler) {
     callback(null, null);
   });
 
+  compiler.plugin('compilation', function () {
+    self.browserSync.notify('Rebuilding');
+  });
+
   compiler.plugin('done', function (stats) {
     if (self.webpackIsWatching) {
       if (self.browserSyncIsRunning) {


### PR DESCRIPTION
This PR adds a notification (if browser-sync's notify option is enabled) on rebuild. It could be extended to allow customization of the message or additional detail as necessary.