### PR TITLE
Updated package.json with webpack version 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "devDependencies": {},
   "peerDependencies": {
     "browser-sync": "^2",
-    "webpack": "^1 || ^2 || ^2.0.0-beta || ^2.1.0-beta || ^2.2.0-rc.0"
+    "webpack": "^1 || ^2 || ^2.0.0-beta || ^2.1.0-beta || ^2.2.0-rc.0 || ^3.0.0-rc.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-sync-webpack-plugin",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "BrowserSync and Webpack integration",
   "keywords": [
     "webpack",
@@ -17,7 +17,7 @@
   "devDependencies": {},
   "peerDependencies": {
     "browser-sync": "^2",
-    "webpack": "^1 || ^2 || ^2.0.0-beta || ^2.1.0-beta || ^2.2.0-rc.0 || ^3.0.0-rc.0"
+    "webpack": "^1 || ^2 || ^2.0.0-beta || ^2.1.0-beta || ^2.2.0-rc.0 || ^3 || ^3.0.0-rc.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Va1/browser-sync-webpack-plugin.git"
+    "url": "https://github.com/msonowal/browser-sync-webpack-plugin.git"
   },
   "homepage": "https://github.com/Va1/browser-sync-webpack-plugin",
   "author": "Valentyn Barmashyn <valpreacher@gmail.com>",


### PR DESCRIPTION
version 1.1.5. another take on fixing peerDependencies warnings.
by adding webpack version 3 to the package.json 