### PR TITLE
passing an anonymous function to as a browser-sync callback that call…

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,3 @@
-const BrowserSyncPlugin = require('./lib/BrowserSyncPlugin')
+const BrowserSyncPlugin = require("./lib/BrowserSyncPlugin");
 
-module.exports = BrowserSyncPlugin
+module.exports = BrowserSyncPlugin;

--- a/lib/BrowserSyncPlugin.js
+++ b/lib/BrowserSyncPlugin.js
@@ -1,62 +1,69 @@
-const browserSync = require('browser-sync')
-const getCssOnlyEmittedAssetsNames = require('./getCssOnlyEmittedAssetsNames')
+const browserSync = require("browser-sync");
+const getCssOnlyEmittedAssetsNames = require("./getCssOnlyEmittedAssetsNames");
 
 const defaultPluginOptions = {
   reload: true,
-  name: 'bs-webpack-plugin',
+  name: "bs-webpack-plugin",
   callback: undefined,
   injectCss: false
-}
+};
 
 class BrowserSyncPlugin {
-  constructor (browserSyncOptions, pluginOptions) {
-    this.browserSyncOptions = Object.assign({}, browserSyncOptions)
-    this.options = Object.assign({}, defaultPluginOptions, pluginOptions)
+  constructor(browserSyncOptions, pluginOptions) {
+    this.browserSyncOptions = Object.assign({}, browserSyncOptions);
+    this.options = Object.assign({}, defaultPluginOptions, pluginOptions);
 
-    this.browserSync = browserSync.create(this.options.name)
-    this.isWebpackWatching = false
-    this.isBrowserSyncRunning = false
+    this.browserSync = browserSync.create(this.options.name);
+    this.isWebpackWatching = false;
+    this.isBrowserSyncRunning = false;
   }
 
-  apply (compiler) {
+  apply(compiler) {
     const watchRunCallback = () => {
-      this.isWebpackWatching = true
-    }
+      this.isWebpackWatching = true;
+    };
     const compilationCallback = () => {
       if (this.isBrowserSyncRunning && this.browserSyncOptions.notify) {
-        this.browserSync.notify('Rebuilding...')
+        this.browserSync.notify("Rebuilding...");
       }
-    }
+    };
     const doneCallback = stats => {
       if (!this.isWebpackWatching) {
-        return
+        return;
       }
 
       if (!this.isBrowserSyncRunning) {
         this.browserSync.init(this.browserSyncOptions, () => {
-          this.options.callback(this.browserSync);
-        })
-        this.isBrowserSyncRunning = true
+          if (this.options.callback) {
+            this.options.callback(this.browserSync);
+          }
+        });
+        this.isBrowserSyncRunning = true;
       }
 
       if (this.options.reload) {
-        this.browserSync.reload(this.options.injectCss && getCssOnlyEmittedAssetsNames(stats))
+        this.browserSync.reload(
+          this.options.injectCss && getCssOnlyEmittedAssetsNames(stats)
+        );
       }
-    }
+    };
 
-    if (typeof compiler.hooks !== 'undefined') {
-      compiler.hooks.watchRun.tap(BrowserSyncPlugin.name, watchRunCallback)
-      compiler.hooks.compilation.tap(BrowserSyncPlugin.name, compilationCallback)
-      compiler.hooks.done.tap(BrowserSyncPlugin.name, doneCallback)
+    if (typeof compiler.hooks !== "undefined") {
+      compiler.hooks.watchRun.tap(BrowserSyncPlugin.name, watchRunCallback);
+      compiler.hooks.compilation.tap(
+        BrowserSyncPlugin.name,
+        compilationCallback
+      );
+      compiler.hooks.done.tap(BrowserSyncPlugin.name, doneCallback);
     } else {
-      compiler.plugin('watch-run', (watching, callback) => {
-        watchRunCallback()
-        callback(null, null)
-      })
-      compiler.plugin('compilation', compilationCallback)
-      compiler.plugin('done', doneCallback)
+      compiler.plugin("watch-run", (watching, callback) => {
+        watchRunCallback();
+        callback(null, null);
+      });
+      compiler.plugin("compilation", compilationCallback);
+      compiler.plugin("done", doneCallback);
     }
   }
 }
 
-module.exports = BrowserSyncPlugin
+module.exports = BrowserSyncPlugin;

--- a/lib/BrowserSyncPlugin.js
+++ b/lib/BrowserSyncPlugin.js
@@ -33,7 +33,9 @@ class BrowserSyncPlugin {
       }
 
       if (!this.isBrowserSyncRunning) {
-        this.browserSync.init(this.browserSyncOptions, this.options.callback)
+        this.browserSync.init(this.browserSyncOptions, () => {
+          this.options.callback(this.browserSync);
+        })
         this.isBrowserSyncRunning = true
       }
 

--- a/lib/getCssOnlyEmittedAssetsNames.js
+++ b/lib/getCssOnlyEmittedAssetsNames.js
@@ -1,12 +1,16 @@
-const { get } = require('lodash')
+const { get } = require("lodash");
 
-function getCssOnlyEmittedAssetsNames (stats) {
-  const assetsStatsMapping = get(stats, 'compilation.assets', {})
-  const assetsNames = Object.keys(assetsStatsMapping)
-  const emittedAssetsNames = assetsNames.filter(assetName => get(assetsStatsMapping, [assetName, 'emitted'], false))
-  const isCssOnlyEmission = emittedAssetsNames.every(assetName => assetName.includes('.css'))
+function getCssOnlyEmittedAssetsNames(stats) {
+	const assetsStatsMapping = get(stats, "compilation.assets", {});
+	const assetsNames = Object.keys(assetsStatsMapping);
+	const emittedAssetsNames = assetsNames.filter(assetName =>
+		get(assetsStatsMapping, [assetName, "emitted"], false)
+	);
+	const isCssOnlyEmission = emittedAssetsNames.every(assetName =>
+		assetName.includes(".css")
+	);
 
-  return isCssOnlyEmission && emittedAssetsNames
+	return isCssOnlyEmission && emittedAssetsNames;
 }
 
-module.exports = getCssOnlyEmittedAssetsNames
+module.exports = getCssOnlyEmittedAssetsNames;


### PR DESCRIPTION
…s the options.callback and passes the browser-sync instance to it as a parameter. This allows for the webpack configurer to manipulate browser sync within the callback.

This new and small feature allows me to file watcher files outside the webpack watch zone, and auto-reload the browser when they change too. I'm building a website where my view and assets sit separately.