### PR TITLE
Use the compilation trigger to determine whether CSS injection should happen instead of emitted asset names.

### DIFF
--- a/lib/BrowserSyncPlugin.js
+++ b/lib/BrowserSyncPlugin.js
@@ -1,11 +1,13 @@
 const browserSync = require('browser-sync')
 const getCssOnlyEmittedAssetsNames = require('./getCssOnlyEmittedAssetsNames')
+const { wasCompilationAboutCSS, CSSEmittedAssetNames } = require('./getEmittedAssetNamesIfTriggerIsCSSLike');
 
 const defaultPluginOptions = {
   reload: true,
   name: 'bs-webpack-plugin',
   callback: undefined,
-  injectCss: false
+  injectCss: false,
+  injectableTriggerFileTypes: /\.s?a?c?(le)?ss/gm
 }
 
 class BrowserSyncPlugin {
@@ -16,11 +18,15 @@ class BrowserSyncPlugin {
     this.browserSync = browserSync.create(this.options.name)
     this.isWebpackWatching = false
     this.isBrowserSyncRunning = false
+    this.compilationTriggerWasAboutCss = false;
   }
 
   apply (compiler) {
-    const watchRunCallback = () => {
+    const watchRunCallback = (compiler) => {
       this.isWebpackWatching = true
+      if (this.options.reload && this.options.injectCss) {
+        this.compilationTriggerWasAboutCss = wasCompilationAboutCSS(compiler, this.options.injectableTriggerFileTypes)
+      }
     }
     const compilationCallback = () => {
       if (this.isBrowserSyncRunning && this.browserSyncOptions.notify) {
@@ -38,7 +44,7 @@ class BrowserSyncPlugin {
       }
 
       if (this.options.reload) {
-        this.browserSync.reload(this.options.injectCss && getCssOnlyEmittedAssetsNames(stats))
+        this.browserSync.reload((this.options.injectCss && this.compilationTriggerWasAboutCss) && CSSEmittedAssetNames(stats))
       }
     }
 

--- a/lib/getEmittedAssetNamesIfTriggerIsCSSLike.js
+++ b/lib/getEmittedAssetNamesIfTriggerIsCSSLike.js
@@ -1,0 +1,15 @@
+function wasCompilationAboutCSS(compiler, expressionConfirmingCompilationWasAboutCSS){
+  const { watchFileSystem } = compiler;
+  const watcher = watchFileSystem.watcher || watchFileSystem.wfs.watcher;
+  const files = Object.keys(watcher.mtimes);
+  return files.every(file => expressionConfirmingCompilationWasAboutCSS.test(file));
+}
+
+function CSSEmittedAssetNames(stats) {
+  const assets = stats.compilation.assets;
+  return Object.keys(assets).filter(fileName => {
+    return assets[fileName].emitted && fileName.includes('.css');
+  });
+}
+
+module.exports = { wasCompilationAboutCSS, CSSEmittedAssetNames }


### PR DESCRIPTION
Per discussion on #78 , I've created this. It might be worth deleting lib/getCssOnlyEmittedAssetsNames.js since I've removed the one call to it's method, but I wasn't sure if that was my place on this adjustment.

I also created an option that defaults to scss/sass/less/css as the regular expression for comparison against the compilation trigger. 