### PR TITLE
feat: Only trigger a reload if browser sync is not paused

### DIFF
--- a/lib/BrowserSyncPlugin.js
+++ b/lib/BrowserSyncPlugin.js
@@ -37,7 +37,7 @@ class BrowserSyncPlugin {
         this.isBrowserSyncRunning = true
       }
 
-      if (this.options.reload) {
+      if (this.options.reload && this.browserSync.active) {
         this.browserSync.reload(this.options.injectCss && getCssOnlyEmittedAssetsNames(stats))
       }
     }


### PR DESCRIPTION
Hi.

Thank you for the plugin. Saved me writing my own one!

I am trying to allow a developer to toggle browser sync, and I would like to use the [http protocol api](https://www.browsersync.io/docs/http-protocol).

With this fix, the plugin correctly checks whether or not browser sync has been paused and prevents triggering a reload.

It's easy to test:

```
fetch('http://localhost:3215/__browser_sync__?method=pause').then((res)=>console.log(res))
// make some changes...no reload event...
fetch('http://localhost:3215/__browser_sync__?method=resume').then((res)=>console.log(res))
// make some changes...reload event!
```
