### PR TITLE
feat: allow `browser-sync` v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "standard": "^11.0.1"
   },
   "peerDependencies": {
-    "browser-sync": "^2",
+    "browser-sync": "^2 || ^3",
     "webpack": "^1 || ^2 || ^3 || ^4 || ^5"
   },
   "repository": {


### PR DESCRIPTION
[v3 drops support for `localtunnel`](https://github.com/BrowserSync/browser-sync/releases/tag/v3.0.1) since it wasn't that used and the dependency has been abandoned and now bring in a vulnerable version of `axios`.

No changes should be needed for this package to support v3, beyond just updating the version constraint for the peer dependency.

Resolves #94
Resolves #97